### PR TITLE
Remove debug print statements

### DIFF
--- a/app/Routes/auth_routes.py
+++ b/app/Routes/auth_routes.py
@@ -144,5 +144,4 @@ async def firebase_login(request: Request, db: AsyncSession = Depends(get_db)):
             }
 
     except Exception as e:
-        print("Firebase login failed:", e)
         raise HTTPException(status_code=401, detail="Invalid Firebase token")

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -51,56 +51,44 @@ async def get_current_user(
     """
     Extract the user from a Bearer token.
     """
-    print(f"🔍 AUTH: Function called")
-    print(f"🔍 AUTH: Credentials: {credentials}")
-    
+
     if not credentials:
-        print("❌ AUTH: No credentials provided")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="No credentials provided",
         )
     
     token = credentials.credentials
-    print(f"🔍 AUTH: Token extracted: {token[:20] if token else 'None'}...")
-    
+
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        print(f"🔍 AUTH: JWT decoded successfully")
-        
+
         user_id: str = payload.get("sub")
-        print(f"🔍 AUTH: User ID from token: {user_id}")
-        
+
         if not user_id:
-            print("❌ AUTH: No user_id in token")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid token: missing subject",
             )
-        
+
         # Fetch user from DB
-        print(f"🔍 AUTH: Looking up user in database...")
         result = await db.execute(select(User).where(User.id == user_id))
         user = result.scalar_one_or_none()
-        
+
         if not user:
-            print(f"❌ AUTH: User {user_id} not found in database")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="User not found",
             )
 
-        print(f"✅ AUTH: User found: {user.id}")
         return user
 
-    except JWTError as e:
-        print(f"❌ AUTH: JWT Error: {e}")
+    except JWTError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
         )
-    except Exception as e:
-        print(f"❌ AUTH: Unexpected error: {e}")
+    except Exception:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication failed",

--- a/app/utils/pushnotification.py
+++ b/app/utils/pushnotification.py
@@ -9,19 +9,17 @@ def send_push(subscription: dict, payload: str):
             vapid_private_key=settings.VAPID_PRIVATE_KEY,
             vapid_claims={"sub": f"mailto:{settings.VAPID_CLAIMS_EMAIL}"}
         )
-        print(f"✅ Push sent: {subscription['endpoint']}, Status: {response.status_code}")
         return response
     except WebPushException as ex:
         status_code = getattr(ex.response, "status_code", None)
-        print(f"🔥 Web push failed: {subscription['endpoint']} | Status: {status_code} | Error: {str(ex)}")
 
         if status_code == 410:
-            print("💀 Subscription is gone — delete from DB.")
+            # handle deletion of subscription from database
         elif status_code == 404:
-            print("❌ Subscription not found.")
+            # handle subscription not found
         elif status_code == 400:
-            print("⚠️ Malformed subscription or payload.")
+            # handle malformed request
         elif status_code == 401:
-            print("🔐 Auth/VAPID key issue.")
+            # handle authentication issues
         return None
 


### PR DESCRIPTION
## Summary
- Remove leftover debug `print` statements from authentication and Firebase auth routes
- Simplify push notification error handling without console output

## Testing
- `python -m pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adc4c7dcf4832da679a43716564189